### PR TITLE
Add lighter success/warning/danger bg colours

### DIFF
--- a/lib/assets/stylesheets/assembly.scss
+++ b/lib/assets/stylesheets/assembly.scss
@@ -11,6 +11,7 @@
 @import "assembly/components";
 @import "assembly/breakpoints";
 
+@import "contrib/colors";
 @import "contrib/icon-size";
 @import "contrib/footer";
 @import "contrib/cards-table";

--- a/lib/assets/stylesheets/contrib/colors.scss
+++ b/lib/assets/stylesheets/contrib/colors.scss
@@ -1,0 +1,7 @@
+$warning-color-light: lighten($warning-color, 30%);
+$danger-color-light: lighten($danger-color, 30%);
+$success-color-light: lighten($success-color, 30%);
+
+.bg-warning-light { background: $warning-color-light; }
+.bg-danger-light { background: $danger-color-light; }
+.bg-success-light { background: $success-color-light; }


### PR DESCRIPTION
Simple PR to allow adding lighter status backgrounds, mainly for the success message when copying text to clipboard (warning and danger added for completeness)